### PR TITLE
Added docker-compose.yml for Cross-Platform Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,17 @@ EXPOSE 80
 EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+ARG BUILDPROFILE=Release
+
 WORKDIR /src
 COPY ["BadgeMeUp.csproj", "."]
 RUN dotnet restore "./BadgeMeUp.csproj"
 COPY . .
 WORKDIR "/src/."
-RUN dotnet build "BadgeMeUp.csproj" -c Release -o /app/build
+RUN dotnet build "BadgeMeUp.csproj" -c ${BUILDPROFILE} -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "BadgeMeUp.csproj" -c Release -o /app/publish
+RUN dotnet publish "BadgeMeUp.csproj" -c ${BUILDPROFILE} -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/Pages/badges/Edit.cshtml.cs
+++ b/Pages/badges/Edit.cshtml.cs
@@ -82,7 +82,7 @@ namespace BadgeMeUp.Pages.Badges
 
                 var resized = ResizeImage(ms);
 
-                updateBadge.BadgeStorageUrl = _badgeImageDb.GetBadgeImageUrl(Badge.Id).AbsoluteUri;
+                updateBadge.BadgeStorageUrl = _badgeImageDb.GetBadgeImageUrl(Badge.Id);
                 await _badgeImageDb.SaveBadgeImage(Badge.Id, resized, "image/jpeg");
             }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - "1433:1433"
     environment:
-      -  ACCEPT_EULA=Y
-      -  SA_PASSWORD=BadgeMeUp1!
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=BadgeMeUp1!
     volumes:
       - badgemeup-mssqlsystem:/var/opt/mssql
       - badgemeup-mssqluser:/var/opt/sqlserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.8"
+services:
+  database:
+    # Runs a local SQL Server 2017 instance to store data
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    container_name: badgemeup-database
+    ports:
+      - "1433:1433"
+    environment:
+      -  ACCEPT_EULA=Y
+      -  SA_PASSWORD=BadgeMeUp1!
+    volumes:
+      - badgemeup-mssqlsystem:/var/opt/mssql
+      - badgemeup-mssqluser:/var/opt/sqlserver
+  storage:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    container_name: badgemeup-storage
+    ports:
+      - 10000:10000
+      - 10001:10001
+      - 10002:10002
+    volumes:
+      - badgemeup-storage:/data
+  webapp:
+    image: badgemeup
+    container_name: badgemeup-webapp
+    depends_on:
+      - database
+      - storage
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args:
+        - BUILDPROFILE=Debug
+    ports:
+      - "9000:80"
+    environment:
+      - CONNECTIONSTRINGS__BADGEDB=Data Source=badgemeup-database;Initial Catalog=badges1;User Id=sa;Password=BadgeMeUp1!;Application Name=badgemeup
+      - CONNECTIONSTRINGS__badgeImageStorage=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://badgemeup-storage:10000/devstoreaccount1;QueueEndpoint=http://badgemeup-storage:10001/devstoreaccount1;
+      - ASPNETCORE_ENVIRONMENT=Development
+      - LOGGING__LOGLEVEL__DEFAULT=Information
+      - DETAILEDERRORS=true
+volumes:
+  badgemeup-mssqlsystem:
+  badgemeup-mssqluser:
+  badgemeup-storage:


### PR DESCRIPTION
Created a docker-compose.yml file that:

- Builds the web app using the current `Dockerfile`
- Creates an instance of SQL Server in a container to be used by the webapp
- Creates an instance of Azurite to be used as a storage emulator for images uploaded by the app

Additionally, made a few minor modifications to support the local storage emulator with images (find/replace the azurite instance name with `localhost` so that images show up properly).

TODO: a devcontainer would be a better solution for active development of the web app, but this at least builds and runs the solution for quick local testing.